### PR TITLE
fix: allow empty scopes in scope-enum check

### DIFF
--- a/source/library/ensure-enum.js
+++ b/source/library/ensure-enum.js
@@ -1,3 +1,3 @@
 export default (value, enums) => {
-	return enums.length === 0 || enums.indexOf(value) > -1;
+	return enums.indexOf(value) > -1;
 };

--- a/source/rules/scope-enum.js
+++ b/source/rules/scope-enum.js
@@ -1,8 +1,13 @@
 import ensureEnum from '../library/ensure-enum';
 
 export default (parsed, when, value) => {
+	if (!parsed.scope) {
+		return [true, ''];
+	}
+
 	const negated = when === 'never';
-	const result = ensureEnum(parsed.scope, value);
+	const result = value.length === 0 || ensureEnum(parsed.scope, value);
+
 	return [
 		negated ? !result : result,
 		[

--- a/test/rules/scope-empty.js
+++ b/test/rules/scope-empty.js
@@ -1,6 +1,6 @@
 import test from 'ava';
-import scopeEmpty from '../../source/rules/scope-empty';
 import {sync as parse} from 'conventional-commits-parser';
+import scopeEmpty from '../../source/rules/scope-empty';
 
 const messages = {
 	plain: 'foo(bar): baz',
@@ -14,56 +14,56 @@ const parsed = {
 	empty: parse(messages.empty)
 };
 
-test('scope-empty with plain message', t => {
+test('scope-empty with plain message it should succeed for empty keyword', t => {
 	const [actual] = scopeEmpty(parsed.plain);
 	const expected = true;
-	t.deepEqual(actual, expected, 'it should succeed for empty keyword');
+	t.deepEqual(actual, expected);
 });
 
-test('scope-empty with plain message', t => {
+test('scope-empty with plain message it should succeed for "never"', t => {
 	const [actual] = scopeEmpty(parsed.plain, 'never');
 	const expected = true;
-	t.deepEqual(actual, expected, 'it should succeed for "never"');
+	t.deepEqual(actual, expected);
 });
 
-test('scope-empty with plain message', t => {
+test('scope-empty with plain message it should fail for "always"', t => {
 	const [actual] = scopeEmpty(parsed.plain, 'always');
 	const expected = false;
-	t.deepEqual(actual, expected, 'it should fail for "always"');
+	t.deepEqual(actual, expected);
 });
 
-test('scope-empty with superfluous message', t => {
+test('scope-empty with superfluous message it should fail for empty keyword', t => {
 	const [actual] = scopeEmpty(parsed.superfluous);
 	const expected = false;
-	t.deepEqual(actual, expected, 'it should fail for empty keyword');
+	t.deepEqual(actual, expected);
 });
 
-test('scope-empty with superfluous message', t => {
+test('scope-empty with superfluous message it should fail for "never"', t => {
 	const [actual] = scopeEmpty(parsed.superfluous, 'never');
 	const expected = false;
-	t.deepEqual(actual, expected, 'it should fail for "never"');
+	t.deepEqual(actual, expected);
 });
 
-test('scope-empty with superfluous message', t => {
+test('scope-empty with superfluous message it should fail for "always"', t => {
 	const [actual] = scopeEmpty(parsed.superfluous, 'always');
 	const expected = true;
-	t.deepEqual(actual, expected, 'it should fail for "always"');
+	t.deepEqual(actual, expected);
 });
 
-test('scope-empty with empty message', t => {
+test('scope-empty with empty message it should fail for empty keyword', t => {
 	const [actual] = scopeEmpty(parsed.empty);
 	const expected = false;
-	t.deepEqual(actual, expected, 'it should fail for empty keyword');
+	t.deepEqual(actual, expected);
 });
 
-test('scope-empty with empty message', t => {
+test('scope-empty with empty message it should fail for "never"', t => {
 	const [actual] = scopeEmpty(parsed.empty, 'never');
 	const expected = false;
-	t.deepEqual(actual, expected, 'it should fail for "never"');
+	t.deepEqual(actual, expected);
 });
 
-test('scope-empty with empty message', t => {
+test('scope-empty with empty message it should fail for "always"', t => {
 	const [actual] = scopeEmpty(parsed.empty, 'always');
 	const expected = true;
-	t.deepEqual(actual, expected, 'it should fail for "always"');
+	t.deepEqual(actual, expected);
 });

--- a/test/rules/scope-enum.js
+++ b/test/rules/scope-enum.js
@@ -1,0 +1,93 @@
+import test from 'ava';
+import {sync as parse} from 'conventional-commits-parser';
+import scopeEnum from '../../source/rules/scope-enum';
+
+const messages = {
+	plain: 'foo(bar): baz',
+	superfluous: 'foo(): baz',
+	empty: 'foo: baz'
+};
+
+const parsed = {
+	plain: parse(messages.plain),
+	superfluous: parse(messages.superfluous),
+	empty: parse(messages.empty)
+};
+
+test('scope-enum with plain message and always should succeed empty enum', t => {
+	const [actual] = scopeEnum(parsed.plain, 'always', []);
+	const expected = true;
+	t.deepEqual(actual, expected);
+});
+
+test('scope-enum with plain message and never should error empty enum', t => {
+	const [actual] = scopeEnum(parsed.plain, 'never', []);
+	const expected = false;
+	t.deepEqual(actual, expected);
+});
+
+test('scope-enum with plain message should succeed correct enum', t => {
+	const [actual] = scopeEnum(parsed.plain, 'always', ['bar']);
+	const expected = true;
+	t.deepEqual(actual, expected);
+});
+
+test('scope-enum with plain message should error false enum', t => {
+	const [actual] = scopeEnum(parsed.plain, 'always', ['foo']);
+	const expected = false;
+	t.deepEqual(actual, expected);
+});
+
+test('scope-enum with plain message should error forbidden enum', t => {
+	const [actual] = scopeEnum(parsed.plain, 'never', ['bar']);
+	const expected = false;
+	t.deepEqual(actual, expected);
+});
+
+test('scope-enum with plain message should succeed forbidden enum', t => {
+	const [actual] = scopeEnum(parsed.plain, 'never', ['foo']);
+	const expected = true;
+	t.deepEqual(actual, expected);
+});
+
+test('scope-enum with superfluous scope should succeed enum', t => {
+	const [actual] = scopeEnum(parsed.superfluous, 'always', ['bar']);
+	const expected = true;
+	t.deepEqual(actual, expected);
+});
+
+test('scope-enum with superfluous scope and "never" should succeed', t => {
+	const [actual] = scopeEnum(parsed.superfluous, 'never', ['bar']);
+	const expected = true;
+	t.deepEqual(actual, expected);
+});
+
+test('scope-enum with superfluous scope and always should succeed empty enum', t => {
+	const [actual] = scopeEnum(parsed.superfluous, 'always', []);
+	const expected = true;
+	t.deepEqual(actual, expected);
+});
+
+test('scope-enum with superfluous scope and never should succeed empty enum', t => {
+	const [actual] = scopeEnum(parsed.superfluous, 'never', []);
+	const expected = true;
+	t.deepEqual(actual, expected);
+});
+
+test('scope-enum with empty scope and always should succeed empty enum', t => {
+	const [actual] = scopeEnum(parsed.superfluous, 'always', []);
+	const expected = true;
+	t.deepEqual(actual, expected);
+});
+
+test('scope-enum with empty scope and always should succeed filled enum', t => {
+	const [actual] = scopeEnum(parsed.superfluous, 'always', ['foo']);
+	const expected = true;
+	t.deepEqual(actual, expected);
+});
+
+test('scope-enum with empty scope and never should succeed empty enum', t => {
+	const [actual] = scopeEnum(parsed.superfluous, 'never', []);
+	const expected = true;
+	t.deepEqual(actual, expected);
+});


### PR DESCRIPTION
## Actual

Disabled `empty-scope` along with defined scope-enum rule yields `scope-enum` errors when linting commits without scope

```js
{
  "extends": ["angular"],
  "rules": {
    "scope-enum": [2, "always", ["api", "system"]]
  }
}
```

```
❯ echo "fix: foo" | ./node_modules/.bin/conventional-changelog-lint
⧗   input: fix: foo
✖   scope must be one of [api, system] [scope-enum]
✖   found 1 problems, 0 warnings
```

## Expected

Disabled `empty-scope` causes commits with empty scope to validate
```
❯ echo "fix: foo" | ./node_modules/.bin/conventional-changelog-lint
⧗   input: fix: foo
✔   found 0 problems, 0 warnings
```