### PR TITLE
fix(rules): export subject-min-length rule

### DIFF
--- a/source/rules/index.js
+++ b/source/rules/index.js
@@ -23,6 +23,7 @@ export default {
 	'subject-full-stop': require('./subject-full-stop'),
 	'subject-leading-capital': require('./subject-leading-capital'),
 	'subject-max-length': require('./subject-max-length'),
+	'subject-min-length': require('./subject-min-length'),
 	'subject-tense': require('./subject-tense'),
 	'type-case': require('./type-case'),
 	'type-empty': require('./type-empty'),


### PR DESCRIPTION
Hi, `subject-min-length` rule in `conventional-changelog-lint@1.1.8` has been missing since [80cd7cc](https://github.com/marionebl/conventional-changelog-lint/commit/80cd7cc312f83dcad5bd99dd698ee2d11bd18e7b#diff-2c0890a5b10b691838ef2e4068896167).

[source/rules/index.js](https://github.com/marionebl/conventional-changelog-lint/blob/89afc0116d10dd65b8b8c68ea4d1254171862ed6/source/rules/index.js) should export [source/rules/subject-min-length.js](https://github.com/marionebl/conventional-changelog-lint/blob/89afc0116d10dd65b8b8c68ea4d1254171862ed6/source/rules/subject-min-length.js) :smiley:  

my-sharable-config/index.js:
```javascript
module.exports = {
    rules: {
        'subject-min-length': [
            1,
            'always',
            0
        ]
    }
};
```

Stack trace:
```sh
/home/user/project/node_modules/conventional-changelog-lint/distribution/cli.js:235
                throw err;
                ^

TypeError: rule is not a function
    at /home/user/project/node_modules/conventional-changelog-lint/distribution/index.js:133:20
    at Array.map (native)
    at _callee$ (/home/user/project/node_modules/conventional-changelog-lint/distribution/index.js:112:10)
    at tryCatch (/home/user/project/node_modules/regenerator-runtime/runtime.js:64:40)
    at Generator.invoke [as _invoke] (/home/user/project/node_modules/regenerator-runtime/runtime.js:299:22)
    at Generator.prototype.(anonymous function) [as next] (/home/user/project/node_modules/regenerator-runtime/runtime.js:116:21)
    at step (/home/user/project/node_modules/babel-runtime/helpers/asyncToGenerator.js:17:30)
    at /home/user/project/node_modules/babel-runtime/helpers/asyncToGenerator.js:35:14
    at F (/home/user/project/node_modules/core-js/library/modules/_export.js:35:28)
    at /home/user/project/node_modules/babel-runtime/helpers/asyncToGenerator.js:14:12
```